### PR TITLE
Add loading and error screens for all routes

### DIFF
--- a/app/cart/error.tsx
+++ b/app/cart/error.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  const handleRetry = () => {
+    reset();
+    setTimeout(() => {
+      window.location.reload();
+    }, 1000);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-stone-900 to-stone-700 p-4">
+      <div className="text-center max-w-md mx-auto">
+        <div className="mb-6">
+          <div className="text-6xl mb-4">🛒</div>
+          <h2 className="text-white text-2xl font-bold mb-3">¡Ups! Error al cargar el carrito</h2>
+          <p className="text-white/80 text-lg mb-6">
+            No pudimos cargar tu carrito en este momento.
+            Por favor, intenta de nuevo.
+          </p>
+        </div>
+
+        <button
+          onClick={handleRetry}
+          className="bg-white text-red-700 px-8 py-3 rounded-full font-semibold hover:bg-gray-100 transition-all duration-200 transform hover:scale-105 shadow-lg hover:shadow-xl"
+        >
+          🔄 Intentar de nuevo
+        </button>
+
+        <p className="text-white/60 text-sm mt-4">
+          Si el problema persiste, contacta a nuestro equipo
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/cart/loading.tsx
+++ b/app/cart/loading.tsx
@@ -1,0 +1,32 @@
+export default function Loading() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-stone-900 to-stone-700 p-4">
+      <div className="text-center max-w-md mx-auto">
+        <div className="mb-6">
+          <div className="text-6xl mb-4 animate-bounce">🛒</div>
+          <h2 className="text-white text-2xl font-bold mb-3">Cargando tu carrito...</h2>
+          <p className="text-white/80 text-lg mb-6">Estamos reuniendo tus productos.</p>
+        </div>
+
+        {/* Loading spinner */}
+        <div className="flex justify-center mb-6">
+          <div className="relative">
+            <div className="w-12 h-12 border-4 border-white/20 border-t-white rounded-full animate-spin"></div>
+            <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2">
+              <div className="w-6 h-6 bg-white rounded-full animate-pulse"></div>
+            </div>
+          </div>
+        </div>
+
+        {/* Loading dots */}
+        <div className="flex justify-center space-x-2">
+          <div className="w-3 h-3 bg-white rounded-full animate-bounce"></div>
+          <div className="w-3 h-3 bg-white rounded-full animate-bounce" style={{ animationDelay: '0.1s' }}></div>
+          <div className="w-3 h-3 bg-white rounded-full animate-bounce" style={{ animationDelay: '0.2s' }}></div>
+        </div>
+
+        <p className="text-white/60 text-sm mt-6">Gracias por tu paciencia</p>
+      </div>
+    </div>
+  );
+}

--- a/app/checkout/error.tsx
+++ b/app/checkout/error.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  const handleRetry = () => {
+    reset();
+    setTimeout(() => {
+      window.location.reload();
+    }, 1000);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-stone-900 to-stone-700 p-4">
+      <div className="text-center max-w-md mx-auto">
+        <div className="mb-6">
+          <div className="text-6xl mb-4">💳</div>
+          <h2 className="text-white text-2xl font-bold mb-3">¡Ups! Error en el checkout</h2>
+          <p className="text-white/80 text-lg mb-6">
+            No pudimos cargar la página de pago en este momento.
+            Esto puede ser temporal, intenta de nuevo.
+          </p>
+        </div>
+
+        <button
+          onClick={handleRetry}
+          className="bg-white text-red-700 px-8 py-3 rounded-full font-semibold hover:bg-gray-100 transition-all duration-200 transform hover:scale-105 shadow-lg hover:shadow-xl"
+        >
+          🔄 Intentar de nuevo
+        </button>
+
+        <p className="text-white/60 text-sm mt-4">
+          Si el problema persiste, contacta a nuestro equipo
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/contact/error.tsx
+++ b/app/contact/error.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  const handleRetry = () => {
+    reset();
+    setTimeout(() => {
+      window.location.reload();
+    }, 1000);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-stone-900 to-stone-700 p-4">
+      <div className="text-center max-w-md mx-auto">
+        <div className="mb-6">
+          <div className="text-6xl mb-4">📞</div>
+          <h2 className="text-white text-2xl font-bold mb-3">¡Ups! Algo salió mal</h2>
+          <p className="text-white/80 text-lg mb-6">
+            No pudimos cargar nuestra información de contacto.
+            Intenta nuevamente más tarde.
+          </p>
+        </div>
+
+        <button
+          onClick={handleRetry}
+          className="bg-white text-red-700 px-8 py-3 rounded-full font-semibold hover:bg-gray-100 transition-all duration-200 transform hover:scale-105 shadow-lg hover:shadow-xl"
+        >
+          🔄 Intentar de nuevo
+        </button>
+
+        <p className="text-white/60 text-sm mt-4">
+          Si el problema persiste, contacta a nuestro equipo
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  const handleRetry = () => {
+    reset();
+    setTimeout(() => {
+      window.location.reload();
+    }, 1000);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-stone-900 to-stone-700 p-4">
+      <div className="text-center max-w-md mx-auto">
+        <div className="mb-6">
+          <div className="text-6xl mb-4">🏠</div>
+          <h2 className="text-white text-2xl font-bold mb-3">¡Ups! Algo salió mal</h2>
+          <p className="text-white/80 text-lg mb-6">
+            No pudimos cargar esta página en este momento.
+            Por favor, inténtalo de nuevo.
+          </p>
+        </div>
+
+        <button
+          onClick={handleRetry}
+          className="bg-white text-red-700 px-8 py-3 rounded-full font-semibold hover:bg-gray-100 transition-all duration-200 transform hover:scale-105 shadow-lg hover:shadow-xl"
+        >
+          🔄 Intentar de nuevo
+        </button>
+
+        <p className="text-white/60 text-sm mt-4">
+          Si el problema persiste, contacta a nuestro equipo
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,36 @@
+export default function Loading() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-stone-900 to-stone-700 p-4">
+      <div className="text-center max-w-md mx-auto">
+        <div className="mb-6">
+          <div className="text-6xl mb-4 animate-bounce">🏠</div>
+          <h2 className="text-white text-2xl font-bold mb-3">
+            Cargando Burger Smoke...
+          </h2>
+          <p className="text-white/80 text-lg mb-6">
+            Estamos preparando la mejor experiencia para ti.
+          </p>
+        </div>
+
+        {/* Loading spinner */}
+        <div className="flex justify-center mb-6">
+          <div className="relative">
+            <div className="w-12 h-12 border-4 border-white/20 border-t-white rounded-full animate-spin"></div>
+            <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2">
+              <div className="w-6 h-6 bg-white rounded-full animate-pulse"></div>
+            </div>
+          </div>
+        </div>
+
+        {/* Loading dots */}
+        <div className="flex justify-center space-x-2">
+          <div className="w-3 h-3 bg-white rounded-full animate-bounce"></div>
+          <div className="w-3 h-3 bg-white rounded-full animate-bounce" style={{ animationDelay: '0.1s' }}></div>
+          <div className="w-3 h-3 bg-white rounded-full animate-bounce" style={{ animationDelay: '0.2s' }}></div>
+        </div>
+
+        <p className="text-white/60 text-sm mt-6">Gracias por tu paciencia</p>
+      </div>
+    </div>
+  );
+}

--- a/app/order-success/error.tsx
+++ b/app/order-success/error.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  const handleRetry = () => {
+    reset();
+    setTimeout(() => {
+      window.location.reload();
+    }, 1000);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-stone-900 to-stone-700 p-4">
+      <div className="text-center max-w-md mx-auto">
+        <div className="mb-6">
+          <div className="text-6xl mb-4">🎉</div>
+          <h2 className="text-white text-2xl font-bold mb-3">¡Ups! Algo salió mal</h2>
+          <p className="text-white/80 text-lg mb-6">
+            No pudimos confirmar tu pedido en este momento.
+            Por favor, intenta de nuevo.
+          </p>
+        </div>
+
+        <button
+          onClick={handleRetry}
+          className="bg-white text-red-700 px-8 py-3 rounded-full font-semibold hover:bg-gray-100 transition-all duration-200 transform hover:scale-105 shadow-lg hover:shadow-xl"
+        >
+          🔄 Intentar de nuevo
+        </button>
+
+        <p className="text-white/60 text-sm mt-4">
+          Si el problema persiste, contacta a nuestro equipo
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/order-success/loading.tsx
+++ b/app/order-success/loading.tsx
@@ -1,0 +1,32 @@
+export default function Loading() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-stone-900 to-stone-700 p-4">
+      <div className="text-center max-w-md mx-auto">
+        <div className="mb-6">
+          <div className="text-6xl mb-4 animate-bounce">🎉</div>
+          <h2 className="text-white text-2xl font-bold mb-3">Confirmando tu pedido...</h2>
+          <p className="text-white/80 text-lg mb-6">Estamos preparando la confirmación.</p>
+        </div>
+
+        {/* Loading spinner */}
+        <div className="flex justify-center mb-6">
+          <div className="relative">
+            <div className="w-12 h-12 border-4 border-white/20 border-t-white rounded-full animate-spin"></div>
+            <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2">
+              <div className="w-6 h-6 bg-white rounded-full animate-pulse"></div>
+            </div>
+          </div>
+        </div>
+
+        {/* Loading dots */}
+        <div className="flex justify-center space-x-2">
+          <div className="w-3 h-3 bg-white rounded-full animate-bounce"></div>
+          <div className="w-3 h-3 bg-white rounded-full animate-bounce" style={{ animationDelay: '0.1s' }}></div>
+          <div className="w-3 h-3 bg-white rounded-full animate-bounce" style={{ animationDelay: '0.2s' }}></div>
+        </div>
+
+        <p className="text-white/60 text-sm mt-6">Gracias por tu paciencia</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add global loading and error screens
- create cart, checkout, contact and order-success loading and error pages

## Testing
- `npm run lint` *(fails: asks to configure ESLint)*
- `npm run build` *(fails: can't download `Inter` font)*

------
https://chatgpt.com/codex/tasks/task_b_685d480ebf30832d8939726d978487dd