### PR TITLE
Improve menu search empty state and dish modal

### DIFF
--- a/components/dish-modal.tsx
+++ b/components/dish-modal.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogHeader,
+  DialogClose,
+} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Textarea } from "@/components/ui/textarea";
@@ -54,22 +60,30 @@ export function DishModal({ dish, isOpen, onClose }: DishModalProps) {
 	const totalPrice = dish.price * quantity;
 
 	return (
-		<Dialog open={isOpen} onOpenChange={onClose}>
-			<DialogContent className="w-[95vw] max-w-md mx-auto max-h-[90vh] overflow-y-auto bg-stone-800 border-none  text-white p-0">
-				{/* Mobile Header with Close Button */}
-				<div className="sticky top-0 bg-stone-800 border-b border-none  p-4 flex items-center justify-between">
-					<DialogTitle className="text-lg font-bold pr-4">
-						{dish.name}
-					</DialogTitle>
-				</div>
+                <Dialog open={isOpen} onOpenChange={onClose}>
+                        <DialogContent className="w-[95vw] max-w-md mx-auto max-h-[90vh] overflow-y-auto bg-stone-800 border-none  text-white p-0">
+                                {/* Header */}
+                                <DialogHeader className="sticky top-0 bg-stone-800 border-b border-none p-4 flex items-center justify-between">
+                                        <DialogTitle className="text-lg font-bold pr-4">{dish.name}</DialogTitle>
+                                        <DialogClose asChild>
+                                                <Button variant="ghost" size="icon" className="text-stone-400 hover:text-white">
+                                                        <X className="h-5 w-5" />
+                                                        <span className="sr-only">Cerrar</span>
+                                                </Button>
+                                        </DialogClose>
+                                </DialogHeader>
 
-				<div className="p-4 space-y-6">
-					{/* Dish Image and Info */}
-					<div className="space-y-3">
-						{/* <div className="aspect-video bg-stone-200 rounded-lg overflow-hidden">
-              <img src={dish.image || "/placeholder.svg"} alt={dish.name} className="w-full h-full object-cover" />
-            </div> */}
-						<div>
+                                <div className="p-4 space-y-6">
+                                        {/* Dish Image and Info */}
+                                        <div className="space-y-3">
+                                                <div className="aspect-video bg-stone-200 rounded-lg overflow-hidden">
+                                                        <img
+                                                                src={dish.image || "/placeholder.svg"}
+                                                                alt={dish.name}
+                                                                className="w-full h-full object-cover"
+                                                        />
+                                                </div>
+                                                <div>
 							<p className="text-stone-400 text-sm mb-3">{dish.description}</p>
 							<div className="flex items-center justify-between">
 								<Badge className="bg-red-700 text-white text-xs">
@@ -169,22 +183,31 @@ export function DishModal({ dish, isOpen, onClose }: DishModalProps) {
 					</div>
 				</div>
 
-				{/* Sticky Footer with Add to Cart */}
-				<div className="sticky bottom-0 bg-stone-800 border-t border-none  p-4">
-					<div className="flex items-center justify-between mb-3">
-						<span className="text-sm text-stone-400">Total:</span>
-						<span className="text-xl font-bold text-white">
-							${totalPrice.toFixed(2)}
-						</span>
-					</div>
-					<Button
-						onClick={handleAddToCart}
-						className="w-full bg-red-700 hover:bg-red-600 h-12 text-base font-semibold"
-						size="lg"
-					>
-						Agregar al Carrito
-					</Button>
-				</div>
+                                {/* Sticky Footer with Add to Cart */}
+                                <div className="sticky bottom-0 bg-stone-800 border-t border-none p-4">
+                                        <div className="flex items-center justify-between mb-3">
+                                                <span className="text-sm text-stone-400">Total:</span>
+                                                <span className="text-xl font-bold text-white">
+                                                        ${totalPrice.toFixed(2)}
+                                                </span>
+                                        </div>
+                                        <div className="flex gap-2">
+                                                <Button
+                                                        variant="outline"
+                                                        onClick={onClose}
+                                                        className="flex-1"
+                                                >
+                                                        Cancelar
+                                                </Button>
+                                                <Button
+                                                        onClick={handleAddToCart}
+                                                        className="flex-1 bg-red-700 hover:bg-red-600 h-12 text-base font-semibold"
+                                                        size="lg"
+                                                >
+                                                        Agregar al Carrito
+                                                </Button>
+                                        </div>
+                                </div>
 			</DialogContent>
 		</Dialog>
 	);

--- a/components/screens/Menu.tsx
+++ b/components/screens/Menu.tsx
@@ -141,13 +141,28 @@ export default function Menu({ menu }: { menu: MenuItem[] }) {
 				))}
 			</div>
 
-			{filteredMenu.length === 0 && (
-				<div className="text-center py-12">
-					<p className="text-gray-400 text-lg">
-						No se encontraron platos que coincidan con tus criterios.
-					</p>
-				</div>
-			)}
+                        {filteredMenu.length === 0 && (
+                                <div className="min-h-[40vh] flex items-center justify-center bg-gradient-to-br from-stone-900 to-stone-700 rounded-lg p-6 my-8">
+                                        <div className="text-center max-w-md mx-auto">
+                                                <div className="text-6xl mb-4 animate-bounce">🔍</div>
+                                                <h2 className="text-white text-2xl font-bold mb-3">
+                                                        No encontramos platos
+                                                </h2>
+                                                <p className="text-white/80 text-lg mb-6">
+                                                        Intenta otro término o revisa la categoría seleccionada.
+                                                </p>
+                                                <Button
+                                                        onClick={() => {
+                                                                setSearchTerm("");
+                                                                setSelectedCategory("Todos");
+                                                        }}
+                                                        className="bg-white text-red-700 px-6 py-2 rounded-full font-semibold hover:bg-gray-100 transition-all"
+                                                >
+                                                        Ver todo el menú
+                                                </Button>
+                                        </div>
+                                </div>
+                        )}
 
 			{selectedDish && (
 				<DishModal


### PR DESCRIPTION
## Summary
- show a nicer message when no dishes match search
- polish the modal used when adding a dish

## Testing
- `npm run lint` *(fails: asks for interactive config)*
- `npm run build` *(fails: can't download fonts)*


------
https://chatgpt.com/codex/tasks/task_b_685eb85edd9c832dbb883d281c6cba83